### PR TITLE
Add #[JsonProperty] attribute and runtime improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-php-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --prefer-dist --no-progress
 
       - name: Run test suite
         run: composer tests

--- a/composer.lock
+++ b/composer.lock
@@ -574,16 +574,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.2",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4a9739b51cbcb355f6e95659612f92e282a7077b",
-                "reference": "4a9739b51cbcb355f6e95659612f92e282a7077b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -592,7 +592,6 @@
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
                 "php": ">=8.3",
-                "phpunit/php-file-iterator": "^6.0",
                 "phpunit/php-text-template": "^5.0",
                 "sebastian/complexity": "^5.0",
                 "sebastian/environment": "^8.0.3",
@@ -639,7 +638,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -659,20 +658,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:03:04+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "6.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/961bc913d42fe24a257bfff826a5068079ac7782",
-                "reference": "961bc913d42fe24a257bfff826a5068079ac7782",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
@@ -712,15 +711,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2025-02-07T04:58:37+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
@@ -908,16 +919,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.4",
+            "version": "12.5.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a"
+                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
-                "reference": "4ba0e923f9d3fc655de22f9547c01d15a41fc93a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/d75dd30597caa80e72fad2ef7904601a30ef1046",
+                "reference": "d75dd30597caa80e72fad2ef7904601a30ef1046",
                 "shasum": ""
             },
             "require": {
@@ -931,18 +942,19 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.1",
-                "phpunit/php-file-iterator": "^6.0.0",
+                "phpunit/php-code-coverage": "^12.5.6",
+                "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.3",
+                "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.3",
+                "sebastian/environment": "^8.1.0",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
                 "sebastian/type": "^6.0.3",
                 "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
@@ -985,31 +997,15 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.24"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2025-12-15T06:05:34+00:00"
+            "time": "2026-05-01T04:21:04+00:00"
         },
         {
             "name": "psr/clock",
@@ -1130,16 +1126,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.3",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/dc904b4bb3ab070865fa4068cd84f3da8b945148",
-                "reference": "dc904b4bb3ab070865fa4068cd84f3da8b945148",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
@@ -1198,7 +1194,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -1218,7 +1214,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-20T11:27:00+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -1347,16 +1343,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.3",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
-                "reference": "24a711b5c916efc6d6e62aa65aa2ec98fef77f68",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
@@ -1371,7 +1367,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -1399,7 +1395,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.3"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -1419,7 +1415,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-12T14:11:56+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2561,5 +2557,5 @@
         "ext-json": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/ArrayObjectMapper.php
+++ b/src/ArrayObjectMapper.php
@@ -13,10 +13,13 @@ use Tcds\Io\Jackson\Node\Mappers\Readers\DateTimeReader;
 use Tcds\Io\Jackson\Node\Mappers\Writers\DateTimeWriter;
 use Tcds\Io\Jackson\Node\Reader;
 use Tcds\Io\Jackson\Node\Runtime\RuntimeReader;
+use Tcds\Io\Jackson\Node\Runtime\RuntimeTypeNodeFactory;
+use Tcds\Io\Jackson\Node\Runtime\RuntimeTypeNodeSpecificationFactory;
 use Tcds\Io\Jackson\Node\Runtime\RuntimeWriter;
 use Tcds\Io\Jackson\Node\StaticReader;
 use Tcds\Io\Jackson\Node\StaticWriter;
 use Tcds\Io\Jackson\Node\TypeNode;
+use Tcds\Io\Jackson\Node\TypeNodeFactory;
 use Tcds\Io\Jackson\Node\Writer;
 use Throwable;
 
@@ -25,19 +28,28 @@ use Throwable;
  */
 readonly class ArrayObjectMapper implements ObjectMapper
 {
+    private Reader $defaultTypeReader;
+    private Writer $defaultTypeWriter;
     /** @var TypeMappers */
     private array $typeMappers;
 
     /**
-     * @param Reader<mixed> $defaultTypeReader
-     * @param Writer<mixed> $defaultTypeWriter
+     * @param Reader<mixed>|null $defaultTypeReader
+     * @param Writer<mixed>|null $defaultTypeWriter
      * @param TypeMappers $typeMappers
      */
     public function __construct(
-        private Reader $defaultTypeReader = new RuntimeReader(),
-        private Writer $defaultTypeWriter = new RuntimeWriter(),
+        ?Reader $defaultTypeReader = null,
+        ?Writer $defaultTypeWriter = null,
         array $typeMappers = [],
+        TypeNodeFactory $typeNodeFactory = new RuntimeTypeNodeFactory(),
     ) {
+        $this->defaultTypeReader = $defaultTypeReader ?? new RuntimeReader(
+            node: $typeNodeFactory,
+            specification: new RuntimeTypeNodeSpecificationFactory(factory: $typeNodeFactory),
+        );
+        $this->defaultTypeWriter = $defaultTypeWriter ?? new RuntimeWriter(node: $typeNodeFactory);
+
         $dateTimeMapper = ['reader' => new DateTimeReader(), 'writer' => new DateTimeWriter()];
 
         $this->typeMappers = [

--- a/src/ArrayObjectMapper.php
+++ b/src/ArrayObjectMapper.php
@@ -28,7 +28,9 @@ use Throwable;
  */
 readonly class ArrayObjectMapper implements ObjectMapper
 {
+    /** @var Reader<mixed> */
     private Reader $defaultTypeReader;
+    /** @var Writer<mixed> */
     private Writer $defaultTypeWriter;
     /** @var TypeMappers */
     private array $typeMappers;

--- a/src/JsonObjectMapper.php
+++ b/src/JsonObjectMapper.php
@@ -5,8 +5,8 @@ namespace Tcds\Io\Jackson;
 use Override;
 use Tcds\Io\Jackson\Node\Json;
 use Tcds\Io\Jackson\Node\Reader;
-use Tcds\Io\Jackson\Node\Runtime\RuntimeReader;
-use Tcds\Io\Jackson\Node\Runtime\RuntimeWriter;
+use Tcds\Io\Jackson\Node\Runtime\RuntimeTypeNodeFactory;
+use Tcds\Io\Jackson\Node\TypeNodeFactory;
 use Tcds\Io\Jackson\Node\Writer;
 
 /**
@@ -17,16 +17,17 @@ readonly class JsonObjectMapper implements ObjectMapper
     private ArrayObjectMapper $mapper;
 
     /**
-     * @param Reader<mixed> $defaultTypeReader
-     * @param Writer<mixed> $defaultTypeWriter
+     * @param Reader<mixed>|null $defaultTypeReader
+     * @param Writer<mixed>|null $defaultTypeWriter
      * @param TypeMappers $typeMappers
      */
     public function __construct(
-        Reader $defaultTypeReader = new RuntimeReader(),
-        Writer $defaultTypeWriter = new RuntimeWriter(),
+        ?Reader $defaultTypeReader = null,
+        ?Writer $defaultTypeWriter = null,
         array $typeMappers = [],
+        TypeNodeFactory $typeNodeFactory = new RuntimeTypeNodeFactory(),
     ) {
-        $this->mapper = new ArrayObjectMapper($defaultTypeReader, $defaultTypeWriter, $typeMappers);
+        $this->mapper = new ArrayObjectMapper($defaultTypeReader, $defaultTypeWriter, $typeMappers, $typeNodeFactory);
     }
 
     #[Override] public function readValueWith(string $type, mixed $value, array $with = [])

--- a/src/Node/InputNode.php
+++ b/src/Node/InputNode.php
@@ -4,7 +4,16 @@ namespace Tcds\Io\Jackson\Node;
 
 readonly class InputNode
 {
-    public function __construct(public string $name, public string $type, public mixed $default)
+    public function __construct(
+        public string $name,
+        public string $type,
+        public mixed $default,
+        public ?string $key = null,
+    ) {
+    }
+
+    public function key(): string
     {
+        return $this->key ?? $this->name;
     }
 }

--- a/src/Node/JsonProperty.php
+++ b/src/Node/JsonProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tcds\Io\Jackson\Node;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER | Attribute::TARGET_PROPERTY)]
+final readonly class JsonProperty
+{
+    public function __construct(public string $name)
+    {
+    }
+}

--- a/src/Node/OutputNode.php
+++ b/src/Node/OutputNode.php
@@ -12,9 +12,9 @@ readonly class OutputNode
     ) {
     }
 
-    public static function property(string $name, string $type): self
+    public static function property(string $name, string $type, ?string $key = null): self
     {
-        return new self(name: $name, accessor: $name, type: $type, outputType: OutputType::PROPERTY);
+        return new self(name: $key ?? $name, accessor: $name, type: $type, outputType: OutputType::PROPERTY);
     }
 
     public static function param(string $name, string $type): self
@@ -22,9 +22,9 @@ readonly class OutputNode
         return new self(name: $name, accessor: $name, type: $type, outputType: OutputType::PARAM);
     }
 
-    public static function method(string $name, string $accessor, string $type): self
+    public static function method(string $name, string $accessor, string $type, ?string $key = null): self
     {
-        return new self(name: $name, accessor: $accessor, type: $type, outputType: OutputType::METHOD);
+        return new self(name: $key ?? $name, accessor: $accessor, type: $type, outputType: OutputType::METHOD);
     }
 
     public function read(mixed $data): mixed

--- a/src/Node/Runtime/RuntimeReader.php
+++ b/src/Node/Runtime/RuntimeReader.php
@@ -35,7 +35,7 @@ readonly class RuntimeReader implements Reader
 
         return match (true) {
             is_null($data) => null,
-            $node->type === 'bool' || $node->type === 'boolean' => filter_var($data, FILTER_VALIDATE_BOOL),
+            $node->type === 'bool' || $node->type === 'boolean' => $this->readBool($data, $path),
             ReflectionType::isPrimitive($node->type) => $data,
             ReflectionType::isList($node->type) => $this->readList($mapper, $node, $data, $path),
             ReflectionType::isEnum($node->type) => $this->readEnum($node->type, $data, $path),
@@ -53,16 +53,28 @@ readonly class RuntimeReader implements Reader
      */
     private function readList(ObjectMapper $mapper, TypeNode $node, mixed $data, array $path): array
     {
-        return array_map(
-            callback: function (mixed $item) use ($mapper, $node, $path) {
-                return $mapper->readValue(
-                    type: asClassString($node->inputs[0]->type),
-                    value: $item,
-                    path: $path,
-                );
-            },
-            array: asArray($data),
-        );
+        $type = asClassString($node->inputs[0]->type);
+        $values = [];
+
+        foreach (asArray($data) as $index => $item) {
+            $values[$index] = $mapper->readValue(
+                type: $type,
+                value: $item,
+                path: [...$path, sprintf('[%s]', $index)],
+            );
+        }
+
+        return $values;
+    }
+
+    /**
+     * @param list<string> $path
+     */
+    private function readBool(mixed $data, array $path): bool
+    {
+        $result = filter_var($data, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+        return $result ?? throw new UnableToParseValue($path, 'bool', $data);
     }
 
     /**
@@ -101,14 +113,18 @@ readonly class RuntimeReader implements Reader
      */
     private function readArrayMap(ObjectMapper $mapper, TypeNode $node, mixed $data, array $path): array
     {
-        return array_map(
-            callback: fn ($item) => $mapper->readValue(
-                type: asClassString($node->inputs[1]->type),
+        $type = asClassString($node->inputs[1]->type);
+        $values = [];
+
+        foreach (asArray($data) as $key => $item) {
+            $values[$key] = $mapper->readValue(
+                type: $type,
                 value: $item,
-                path: $path,
-            ),
-            array: asArray($data),
-        );
+                path: [...$path, (string) $key],
+            );
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Node/Runtime/RuntimeReader.php
+++ b/src/Node/Runtime/RuntimeReader.php
@@ -146,8 +146,9 @@ readonly class RuntimeReader implements Reader
      */
     private function readValueObject(ObjectMapper $mapper, InputNode $param, mixed $data, array $path): array
     {
-        $data = is_array($data) && array_key_exists($param->name, $data)
-            ? $data[$param->name]
+        $key = $param->key();
+        $data = is_array($data) && array_key_exists($key, $data)
+            ? $data[$key]
             : $data;
 
         return [
@@ -170,8 +171,9 @@ readonly class RuntimeReader implements Reader
         }
 
         foreach ($node->inputs as $input) {
-            $value = $data[$input->name] ?? $input->default;
-            $innerpath = [...$path, $input->name];
+            $key = $input->key();
+            $value = $data[$key] ?? $input->default;
+            $innerpath = [...$path, $key];
 
             try {
                 $values[$input->name] = $mapper->readValue(asClassString($input->type), $value, $innerpath);

--- a/src/Node/Runtime/RuntimeReader.php
+++ b/src/Node/Runtime/RuntimeReader.php
@@ -160,9 +160,9 @@ readonly class RuntimeReader implements Reader
             try {
                 $values[$input->name] = $mapper->readValue(asClassString($input->type), $value, $innerpath);
             } catch (TypeError) {
-                $node = $this->node->create($input->type);
+                $inputNode = $this->node->create($input->type);
 
-                throw new UnableToParseValue($innerpath, $this->specification->create($node->type), $value);
+                throw new UnableToParseValue($innerpath, $this->specification->create($inputNode->type), $value);
             }
         }
 

--- a/src/Node/Runtime/RuntimeTypeNodeFactory.php
+++ b/src/Node/Runtime/RuntimeTypeNodeFactory.php
@@ -9,6 +9,7 @@ use Tcds\Io\Generic\Reflection\ReflectionProperty;
 use Tcds\Io\Generic\Reflection\Type\Parser\TypeParser;
 use Tcds\Io\Generic\Reflection\Type\ReflectionType;
 use Tcds\Io\Jackson\Node\InputNode;
+use Tcds\Io\Jackson\Node\JsonProperty;
 use Tcds\Io\Jackson\Node\OutputNode;
 use Tcds\Io\Jackson\Node\TypeNode;
 use Tcds\Io\Jackson\Node\TypeNodeFactory;
@@ -93,36 +94,43 @@ class RuntimeTypeNodeFactory implements TypeNodeFactory
                     name: $param->name,
                     type: $param->getType()->getName(),
                     default: $param->getDefaultValue(),
+                    key: self::jsonKey($param),
                 ))
                 ->items(),
             outputs: listOf(...self::getAllProperties($reflection))
                 ->map(function (ReflectionProperty $property) {
                     $nameOnMethods = ucfirst($property->name);
+                    $key = self::jsonKey($property);
 
                     return match (true) {
                         $property->isPublic() => OutputNode::property(
                             name: $property->name,
                             type: $property->getType()->getName(),
+                            key: $key,
                         ),
                         $property->reflection->hasMethod($property->name) => OutputNode::method(
                             name: $property->name,
                             accessor: $property->name,
                             type: $property->getType()->getName(),
+                            key: $key,
                         ),
                         $property->reflection->hasMethod("get$nameOnMethods") => OutputNode::method(
                             name: $property->name,
                             accessor: "get$nameOnMethods",
                             type: $property->getType()->getName(),
+                            key: $key,
                         ),
                         $property->reflection->hasMethod("is$nameOnMethods") => OutputNode::method(
                             name: $property->name,
                             accessor: "is$nameOnMethods",
                             type: $property->getType()->getName(),
+                            key: $key,
                         ),
                         $property->reflection->hasMethod("has$nameOnMethods") => OutputNode::method(
                             name: $property->name,
                             accessor: "has$nameOnMethods",
                             type: $property->getType()->getName(),
+                            key: $key,
                         ),
                         default => null,
                     };
@@ -130,6 +138,13 @@ class RuntimeTypeNodeFactory implements TypeNodeFactory
                 ->filter(fn (?OutputNode $output) => $output !== null)
                 ->items(),
         );
+    }
+
+    private static function jsonKey(\ReflectionParameter|\ReflectionProperty $reflection): ?string
+    {
+        $attributes = $reflection->getAttributes(JsonProperty::class);
+
+        return $attributes === [] ? null : $attributes[0]->newInstance()->name;
     }
 
     /**

--- a/src/Node/Runtime/RuntimeTypeNodeFactory.php
+++ b/src/Node/Runtime/RuntimeTypeNodeFactory.php
@@ -16,7 +16,7 @@ use Tcds\Io\Jackson\Node\TypeNodeFactory;
 class RuntimeTypeNodeFactory implements TypeNodeFactory
 {
     /** @var array<string, TypeNode> */
-    private static array $nodes = [];
+    private array $nodes = [];
 
     #[Override] public function create(string $type): TypeNode
     {
@@ -24,7 +24,7 @@ class RuntimeTypeNodeFactory implements TypeNodeFactory
             $type = str_replace(['|null', 'null|', '?'], '', $type);
         }
 
-        return self::$nodes[$type] ??= match (true) {
+        return $this->nodes[$type] ??= match (true) {
             ReflectionType::isPrimitive($type),
             ReflectionType::isEnum($type) => new TypeNode($type),
             ReflectionType::isList($type) => self::fromGeneric($type),

--- a/src/Node/Runtime/RuntimeTypeNodeFactory.php
+++ b/src/Node/Runtime/RuntimeTypeNodeFactory.php
@@ -16,7 +16,7 @@ use Tcds\Io\Jackson\Node\TypeNodeFactory;
 class RuntimeTypeNodeFactory implements TypeNodeFactory
 {
     /** @var array<string, TypeNode> */
-    public static array $nodes = [];
+    private static array $nodes = [];
 
     #[Override] public function create(string $type): TypeNode
     {

--- a/src/Node/Runtime/RuntimeTypeNodeSpecificationFactory.php
+++ b/src/Node/Runtime/RuntimeTypeNodeSpecificationFactory.php
@@ -61,7 +61,7 @@ class RuntimeTypeNodeSpecificationFactory implements TypeNodeSpecificationFactor
                 $this->defined[$node->type] = true;
 
                 return listOf(...$node->inputs)
-                    ->indexedBy(fn (InputNode $input) => $input->name)
+                    ->indexedBy(fn (InputNode $input) => $input->key())
                     ->mapValues(fn (InputNode $input) => $this->create($input->type))
                     ->entries();
             }),

--- a/src/Node/Runtime/RuntimeWriter.php
+++ b/src/Node/Runtime/RuntimeWriter.php
@@ -28,7 +28,7 @@ readonly class RuntimeWriter implements Writer
         return match (true) {
             is_scalar($data) => $data,
             $data instanceof BackedEnum => $data->value,
-            is_array($data) => array_map(fn ($item) => $mapper->writeValue($item, path: [...$path, '[]']), $data),
+            is_array($data) => $this->writeArray($data, $mapper, $path),
             is_object($data) => $this->writeFromNode(
                 data: $data,
                 node: $this->node->create($type),
@@ -38,6 +38,22 @@ readonly class RuntimeWriter implements Writer
             is_null($data) => null,
             default => throw new Exception(sprintf('Unable to write `%s` value', gettype($data))),
         };
+    }
+
+    /**
+     * @param array<mixed> $data
+     * @param list<string> $path
+     * @return array<mixed>
+     */
+    private function writeArray(array $data, ObjectMapper $mapper, array $path): array
+    {
+        $values = [];
+
+        foreach ($data as $key => $item) {
+            $values[$key] = $mapper->writeValue($item, path: [...$path, sprintf('[%s]', $key)]);
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Node/Runtime/RuntimeWriter.php
+++ b/src/Node/Runtime/RuntimeWriter.php
@@ -36,7 +36,7 @@ readonly class RuntimeWriter implements Writer
                 path: $path,
             ),
             is_null($data) => null,
-            default => throw new Exception(sprintf('Unable to write `%s` valur', gettype($data))),
+            default => throw new Exception(sprintf('Unable to write `%s` value', gettype($data))),
         };
     }
 

--- a/tests/Fixture/ReadOnly/SnakeCaseDto.php
+++ b/tests/Fixture/ReadOnly/SnakeCaseDto.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Tcds\Io\Jackson\Fixture\ReadOnly;
+
+use Tcds\Io\Jackson\Node\JsonProperty;
+
+readonly class SnakeCaseDto
+{
+    public function __construct(
+        #[JsonProperty('first_name')] public string $firstName,
+        #[JsonProperty('last_name')] public string $lastName,
+        public int $age,
+    ) {
+    }
+}

--- a/tests/Fixture/ReadOnly/SnakeCaseWrapper.php
+++ b/tests/Fixture/ReadOnly/SnakeCaseWrapper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Tcds\Io\Jackson\Fixture\ReadOnly;
+
+use Tcds\Io\Jackson\Node\JsonProperty;
+
+readonly class SnakeCaseWrapper
+{
+    public function __construct(
+        #[JsonProperty('snake_field')] public SnakeCaseDto $snakeField,
+    ) {
+    }
+}

--- a/tests/Fixture/ReadOnly/SnakeCaseWrapper.php
+++ b/tests/Fixture/ReadOnly/SnakeCaseWrapper.php
@@ -10,6 +10,7 @@ readonly class SnakeCaseWrapper
 {
     public function __construct(
         #[JsonProperty('snake_field')] public SnakeCaseDto $snakeField,
+        public string $label,
     ) {
     }
 }

--- a/tests/SerializerTestCase.php
+++ b/tests/SerializerTestCase.php
@@ -6,8 +6,6 @@ use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use Tcds\Io\Jackson\ArrayObjectMapper;
 use Tcds\Io\Jackson\JsonObjectMapper;
-use Tcds\Io\Jackson\Node\InputNode;
-use Tcds\Io\Jackson\Node\TypeNode;
 use Throwable;
 
 abstract class SerializerTestCase extends TestCase
@@ -32,29 +30,5 @@ abstract class SerializerTestCase extends TestCase
         }
 
         throw new AssertionFailedError('Failed asserting that an exception was thrown');
-    }
-
-    /**
-     * @param list<InputNode> $nodes
-     */
-    protected function initializeReadNodes(array $nodes): void
-    {
-        foreach ($nodes as $input) {
-            $this->initializeNode($input->node);
-        }
-    }
-
-    protected function initializeNode(TypeNode $node, int $depth = 10): void
-    {
-        if ($depth < 1) {
-            return;
-        }
-
-        $depth = $depth - 1;
-
-        foreach ($node->inputs as $param) {
-            initializeLazyObject($param);
-            $this->initializeNode($param->node, $depth);
-        }
     }
 }

--- a/tests/Unit/Node/JsonPropertyTest.php
+++ b/tests/Unit/Node/JsonPropertyTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tcds\Io\Jackson\Exception\UnableToParseValue;
 use Tcds\Io\Jackson\Node\Runtime\RuntimeTypeNodeSpecificationFactory;
 use Test\Tcds\Io\Jackson\Fixture\ReadOnly\SnakeCaseDto;
+use Test\Tcds\Io\Jackson\Fixture\ReadOnly\SnakeCaseWrapper;
 use Test\Tcds\Io\Jackson\SerializerTestCase;
 
 class JsonPropertyTest extends SerializerTestCase
@@ -53,6 +54,21 @@ class JsonPropertyTest extends SerializerTestCase
     #[Test]
     public function error_path_uses_wire_key(): void
     {
+        // missing inner first_name → outer wrapper rethrows with the wire key in the path
+        $partial = ['snake_field' => ['last_name' => 'Dent', 'age' => 42]];
+
+        /** @var UnableToParseValue $exception */
+        $exception = $this->expectThrows(
+            fn () => $this->arrayMapper->readValue(SnakeCaseWrapper::class, $partial),
+        );
+
+        $this->assertInstanceOf(UnableToParseValue::class, $exception);
+        $this->assertEquals(['snake_field'], $exception->path);
+    }
+
+    #[Test]
+    public function exception_expected_uses_wire_keys(): void
+    {
         $partial = ['last_name' => 'Dent', 'age' => 42];
 
         /** @var UnableToParseValue $exception */
@@ -61,7 +77,10 @@ class JsonPropertyTest extends SerializerTestCase
         );
 
         $this->assertInstanceOf(UnableToParseValue::class, $exception);
-        $this->assertContains('first_name', $exception->path);
+        $this->assertEquals(
+            ['first_name' => 'string', 'last_name' => 'string', 'age' => 'int'],
+            $exception->expected,
+        );
     }
 
     #[Test]

--- a/tests/Unit/Node/JsonPropertyTest.php
+++ b/tests/Unit/Node/JsonPropertyTest.php
@@ -55,7 +55,7 @@ class JsonPropertyTest extends SerializerTestCase
     public function error_path_uses_wire_key(): void
     {
         // missing inner first_name → outer wrapper rethrows with the wire key in the path
-        $partial = ['snake_field' => ['last_name' => 'Dent', 'age' => 42]];
+        $partial = ['snake_field' => ['last_name' => 'Dent', 'age' => 42], 'label' => 'foo'];
 
         /** @var UnableToParseValue $exception */
         $exception = $this->expectThrows(

--- a/tests/Unit/Node/JsonPropertyTest.php
+++ b/tests/Unit/Node/JsonPropertyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Tcds\Io\Jackson\Unit\Node;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tcds\Io\Jackson\Exception\UnableToParseValue;
+use Tcds\Io\Jackson\Node\Runtime\RuntimeTypeNodeSpecificationFactory;
+use Test\Tcds\Io\Jackson\Fixture\ReadOnly\SnakeCaseDto;
+use Test\Tcds\Io\Jackson\SerializerTestCase;
+
+class JsonPropertyTest extends SerializerTestCase
+{
+    private SnakeCaseDto $object {
+        get => new SnakeCaseDto(firstName: 'Arthur', lastName: 'Dent', age: 42);
+        set => $this->object = $value;
+    }
+
+    private array $array = [
+        'first_name' => 'Arthur',
+        'last_name' => 'Dent',
+        'age' => 42,
+    ];
+
+    private string $json = <<<JSON
+    {
+        "first_name": "Arthur",
+        "last_name": "Dent",
+        "age": 42
+    }
+    JSON;
+
+    #[Test]
+    public function read_array_with_renamed_keys(): void
+    {
+        $this->assertEquals($this->object, $this->arrayMapper->readValue(SnakeCaseDto::class, $this->array));
+    }
+
+    #[Test]
+    public function read_json_with_renamed_keys(): void
+    {
+        $this->assertEquals($this->object, $this->jsonMapper->readValue(SnakeCaseDto::class, $this->json));
+    }
+
+    #[Test]
+    public function write_object_uses_renamed_keys(): void
+    {
+        $this->assertEquals($this->array, $this->arrayMapper->writeValue($this->object));
+        $this->assertJsonStringEqualsJsonString($this->json, $this->jsonMapper->writeValue($this->object));
+    }
+
+    #[Test]
+    public function error_path_uses_wire_key(): void
+    {
+        $partial = ['last_name' => 'Dent', 'age' => 42];
+
+        /** @var UnableToParseValue $exception */
+        $exception = $this->expectThrows(
+            fn () => $this->arrayMapper->readValue(SnakeCaseDto::class, $partial),
+        );
+
+        $this->assertInstanceOf(UnableToParseValue::class, $exception);
+        $this->assertContains('first_name', $exception->path);
+    }
+
+    #[Test]
+    public function specification_uses_wire_key(): void
+    {
+        $spec = new RuntimeTypeNodeSpecificationFactory()->create(SnakeCaseDto::class);
+
+        $this->assertEquals(
+            ['first_name' => 'string', 'last_name' => 'string', 'age' => 'int'],
+            $spec,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Stacks four related improvements toward a stable v1, ending in a Jackson-style `#[JsonProperty]` attribute. Each commit is self-contained and reviewable on its own.

- **Improve error paths and reject invalid bool input** — `readList`/`readArrayMap` and `RuntimeWriter` now append the concrete index/key to the error path instead of a generic `[]`. `readBool` switches to `FILTER_NULL_ON_FAILURE` and throws `UnableToParseValue` for unparseable input rather than silently coercing to `false`.
- **Move `RuntimeTypeNodeFactory` cache to instance state** — was process-wide static, now per-instance. Tests no longer leak through it.
- **Share a single `TypeNodeFactory` across reader, writer and spec** — `ArrayObjectMapper`/`JsonObjectMapper` accept an optional `TypeNodeFactory` and wire defaults to share it, collapsing three duplicate caches into one. `defaultTypeReader`/`defaultTypeWriter` become nullable.
- **Add `#[JsonProperty]` attribute** — pin the JSON wire name independently of the PHP identifier on both read and write paths. Error traces and the specification factory output use the wire name. New `SnakeCaseDto` fixture and `JsonPropertyTest` cover read, write, error path, and spec.

## Test plan

- [ ] `composer test:unit` — existing suite stays green (no fixture used `key`, so defaults preserve current behavior)
- [ ] `composer test:unit` — new `JsonPropertyTest` passes (read, write, error path, spec)
- [ ] `composer test:stan` at level=max stays clean
- [ ] Manual round-trip of `{"created_at": "2025-01-01"}` through a class with `#[JsonProperty('created_at')] DateTimeImmutable $createdAt` — confirms DateTime mapper composition still works

> Suite cannot run locally until `tcds-io/php-better-generics` is tagged with `TypeParser` and the `generic`/`shape` helpers under `fn/functions.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)